### PR TITLE
v0.1.2: add support for generic-array v0.13.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v0.2.0] - 2019-08-29
+## [v0.1.2] - 2019-11-22
+
+### Added
+
+- Support for v0.13.x of `generic-array`, in addition to the existing support
+  for v0.12.x of `generic-array`.
+
+## [v0.2.0] - 2019-08-29 - YANKED
 
 - The 0.1.1 release was a breaking change, now in 0.2.0
 
@@ -19,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Initial release
 
-[Unreleased]: https://github.com/japaric/as-slice/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/japaric/as-slice/compare/v0.1.2...HEAD
+[v0.1.2]: https://github.com/japaric/as-slice/compare/v0.1.1...v0.1.2
 [v0.2.0]: https://github.com/japaric/as-slice/compare/v0.1.1...v0.2.0
 [v0.1.1]: https://github.com/japaric/as-slice/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,11 @@ license = "MIT OR Apache-2.0"
 name = "as-slice"
 readme = "README.md"
 repository = "https://github.com/japaric/as-slice"
-version = "0.2.0"
+version = "0.1.2"
 
 [dependencies]
-generic-array = "0.13.0"
+generic-array = "0.12.0"
+ga13 = { package = "generic-array", version = "0.13.0" }
 
 [dependencies.stable_deref_trait]
 default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,15 +7,19 @@
 //! example, a bound `T: StableDeref + AsMutSlice<Element = u8> + 'static` will accepts types like
 //! `&'static mut [u8]`, `&'static mut [u8; 128]` and `&'static mut GenericArray<u8, U1024>` -- all
 //! of them are appropriate for DMA transfers.
+//!
+//! # Minimal Supported Rust Version (MSRV)
+//!
+//! This crate is guaranteed to compile on stable Rust 1.31 and up. It *might* compile on older
+//! versions but that may change in any new patch release.
 
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![no_std]
 
 extern crate generic_array;
+extern crate ga13;
 extern crate stable_deref_trait;
-
-use generic_array::{ArrayLength, GenericArray};
 
 /// Something that can be seen as an immutable slice
 ///
@@ -83,9 +87,9 @@ impl<T> AsMutSlice for [T] {
     }
 }
 
-impl<T, N> AsSlice for GenericArray<T, N>
+impl<T, N> AsSlice for generic_array::GenericArray<T, N>
 where
-    N: ArrayLength<T>,
+    N: generic_array::ArrayLength<T>,
 {
     type Element = T;
 
@@ -94,9 +98,29 @@ where
     }
 }
 
-impl<T, N> AsMutSlice for GenericArray<T, N>
+impl<T, N> AsMutSlice for generic_array::GenericArray<T, N>
 where
-    N: ArrayLength<T>,
+    N: generic_array::ArrayLength<T>,
+{
+    fn as_mut_slice(&mut self) -> &mut [T] {
+        &mut **self
+    }
+}
+
+impl<T, N> AsSlice for ga13::GenericArray<T, N>
+where
+    N: ga13::ArrayLength<T>,
+{
+    type Element = T;
+
+    fn as_slice(&self) -> &[T] {
+        &**self
+    }
+}
+
+impl<T, N> AsMutSlice for ga13::GenericArray<T, N>
+where
+    N: ga13::ArrayLength<T>,
 {
     fn as_mut_slice(&mut self) -> &mut [T] {
         &mut **self


### PR DESCRIPTION
also bump and document / guarantee the MSRV

closes #4 

r? @korken89 

This PR implements option I ("bump the MSRV") described in #4. I also tried option II ("Cargo feature") locally but this option also bumped the MSRV to 1.31 because there's no Cargo support for renaming dependencies before 1.31 so you can't depend on two versions of the same crate (AFAICT).